### PR TITLE
[Mackerel Endpoint] support service metric alert, subject shows more information

### DIFF
--- a/app/controllers/topics_controller.rb
+++ b/app/controllers/topics_controller.rb
@@ -112,6 +112,8 @@ class TopicsController < ApplicationController
       subject += "Service: #{data['service']['name']}"
     end
 
+    subject += "#{data['alert']['monitorName']} "
+
     subject += data['alert']['metricLabel'] ? "#{data['alert']['metricLabel']} : #{data['metricValue']}" : ""
     description = JSON.pretty_generate(data)
 


### PR DESCRIPTION
https://mackerel.io/ja/docs/entry/howto/alerts/webhook

- ignore `status: ok` alert.
- support Service metric alert.
- subject shows more information.